### PR TITLE
Fixed issue with google returning ZERO_RESULTS

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -46,6 +46,9 @@ class Geocoder {
     if (isset($results['error_message'])) {
       return null;
     }
+    if(isset($results['status']) && $results['status'] == 'ZERO_RESULTS'){
+      return null;
+    }
 
     return $results['results'][0]['geometry']['location'];
   }

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -52,4 +52,11 @@ class GeocoderTest extends \PHPUnit_Framework_TestCase
     $this->assertInternalType("float", $result);
     $this->assertTrue(!empty($result));
   }
+
+  public function testZeroResults()
+  {
+    $results = $this->geocoder->getCoordinates("N/A, N/A, VA N/A");
+
+    $this->assertNull($results);
+  }
 }


### PR DESCRIPTION
A user of my app inputted "N/A" for all of the address fields except the state. Laravel was throwing an application exception for an undefined offset of 0. After a bit of digging I found this line in your code:

    return $results['results'][0]['geometry']['location'];

Which typically work great. However, in this case, when my app was sending the address "N/A, N/A, VA N/A", Google was returning this:

  [
    "results" => []
    "status" => "ZERO_RESULTS"
  ]

You can see this live here (of course, add your own API key):
https://maps.googleapis.com/maps/api/geocode/json?address=N/A,+N/A,+VA+N/A&key=

I am added an extra check to your code along with a corresponding test:

if(isset($results['status']) && $results['status'] == 'ZERO_RESULTS'){
    return null;
}

This is working perfectly for me.